### PR TITLE
Copy additional keywords into new instance

### DIFF
--- a/easyjailbreak/datasets/instance.py
+++ b/easyjailbreak/datasets/instance.py
@@ -61,7 +61,8 @@ class Instance:
             parents=[i for i in self.parents],
             children=[i for i in self.children],
             attack_attrs=copy.deepcopy(self.attack_attrs))
-        new_Instance._data = copy.deepcopy(self._data)
+        rest_data = {key: value for key, value in self._data.items() if key not in new_Instance._data}
+        new_Instance._data.update(copy.deepcopy(rest_data))
         return new_Instance
 
     def delete(self, *keys):

--- a/easyjailbreak/datasets/instance.py
+++ b/easyjailbreak/datasets/instance.py
@@ -61,6 +61,7 @@ class Instance:
             parents=[i for i in self.parents],
             children=[i for i in self.children],
             attack_attrs=copy.deepcopy(self.attack_attrs))
+        new_Instance._data = copy.deepcopy(self._data)
         return new_Instance
 
     def delete(self, *keys):


### PR DESCRIPTION
Now, additional keywords stored in _data are also copied into the newly generated instance