### PR TITLE
Add MiniMax as first-class LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,23 @@ from easyjailbreak.models.huggingface_model import HuggingfaceModel
 target_model = HuggingfaceModel(model_name_or_path='meta-llama/Llama-2-7b-chat-hf',
                                 model_name='llama-2')
 
-# use the target_model to generate response based on any input. Here is an example.  
+# use the target_model to generate response based on any input. Here is an example.
 target_response = target_model.generate(messages=['how to make a bomb?'])
+```
+
+EasyJailbreak also supports cloud-hosted models. For example, to use [MiniMax](https://www.minimaxi.com) models:
+
+```python
+from easyjailbreak.models.minimax_model import MiniMaxModel
+
+# MiniMax-M2.7 (204K context) via OpenAI-compatible API
+target_model = MiniMaxModel(api_keys='YOUR_MINIMAX_API_KEY')
+
+# Or specify a different model variant
+target_model = MiniMaxModel(
+    api_keys='YOUR_MINIMAX_API_KEY',
+    model_name='MiniMax-M2.7-highspeed',
+)
 ```
 
 #### 2. Load Dataset and initialize Seed

--- a/easyjailbreak/models/__init__.py
+++ b/easyjailbreak/models/__init__.py
@@ -1,6 +1,7 @@
 from .model_base import ModelBase, WhiteBoxModelBase, BlackBoxModelBase
 from .huggingface_model import HuggingfaceModel, from_pretrained
 from .openai_model import OpenaiModel
+from .minimax_model import MiniMaxModel
 from .wenxinyiyan_model import WenxinyiyanModel
 
-__all__ = ['ModelBase', 'WhiteBoxModelBase', 'BlackBoxModelBase', 'HuggingfaceModel', 'from_pretrained', 'OpenaiModel', 'WenxinyiyanModel']
+__all__ = ['ModelBase', 'WhiteBoxModelBase', 'BlackBoxModelBase', 'HuggingfaceModel', 'from_pretrained', 'OpenaiModel', 'MiniMaxModel', 'WenxinyiyanModel']

--- a/easyjailbreak/models/minimax_model.py
+++ b/easyjailbreak/models/minimax_model.py
@@ -1,0 +1,88 @@
+import re
+from .openai_model import OpenaiModel
+
+
+class MiniMaxModel(OpenaiModel):
+    """
+    MiniMax model wrapper using the OpenAI-compatible API.
+
+    MiniMax provides large language models (MiniMax-M2.7, MiniMax-M2.7-highspeed,
+    etc.) accessible through an OpenAI-compatible chat completions endpoint at
+    ``https://api.minimax.io/v1``.
+
+    Since ``MiniMaxModel`` inherits from :class:`OpenaiModel`, it is recognised
+    by every ``isinstance(model, OpenaiModel)`` check throughout the framework
+    (e.g. PAIR, TAP, IntrospectGeneration) without any modifications.
+
+    Example
+    -------
+    >>> from easyjailbreak.models.minimax_model import MiniMaxModel
+    >>> model = MiniMaxModel(api_keys='YOUR_MINIMAX_API_KEY')
+    >>> response = model.generate('Hello, how are you?')
+    """
+
+    MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
+    DEFAULT_MODEL = 'MiniMax-M2.7'
+
+    # Regex to strip <think>…</think> reasoning blocks that MiniMax M2.7 may
+    # emit when chain-of-thought is enabled.
+    _THINK_TAG_RE = re.compile(r'<think>.*?</think>\s*', re.DOTALL)
+
+    def __init__(
+        self,
+        api_keys: str,
+        model_name: str = DEFAULT_MODEL,
+        generation_config=None,
+    ):
+        """
+        Initializes the MiniMax model.
+
+        :param str api_keys: MiniMax API key (``MINIMAX_API_KEY``).
+        :param str model_name: Model identifier, defaults to ``'MiniMax-M2.7'``.
+            Other options include ``'MiniMax-M2.7-highspeed'``,
+            ``'MiniMax-M2.5'``, ``'MiniMax-M2.5-highspeed'``.
+        :param dict generation_config: Extra generation parameters forwarded to
+            the chat completions API.  Temperature values are automatically
+            clamped to the MiniMax-supported range ``(0, 1]``.
+        """
+        if generation_config is not None:
+            generation_config = self._clamp_temperature(dict(generation_config))
+        super().__init__(
+            model_name=model_name,
+            api_keys=api_keys,
+            generation_config=generation_config,
+            base_url=self.MINIMAX_BASE_URL,
+        )
+
+    # ------------------------------------------------------------------
+    # Temperature clamping
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _clamp_temperature(config: dict) -> dict:
+        """Clamp ``temperature`` to the MiniMax-supported range ``(0, 1]``."""
+        if 'temperature' in config:
+            t = config['temperature']
+            if t is not None:
+                config['temperature'] = max(0.01, min(float(t), 1.0))
+        return config
+
+    # ------------------------------------------------------------------
+    # Think-tag stripping
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _strip_think_tags(cls, text: str | None) -> str | None:
+        """Remove ``<think>…</think>`` blocks from model output."""
+        if text is None:
+            return None
+        return cls._THINK_TAG_RE.sub('', text).strip()
+
+    # ------------------------------------------------------------------
+    # Overrides
+    # ------------------------------------------------------------------
+
+    def generate(self, messages, clear_old_history=True, **kwargs):
+        kwargs = self._clamp_temperature(dict(kwargs))
+        response = super().generate(messages, clear_old_history=clear_old_history, **kwargs)
+        return self._strip_think_tags(response)

--- a/test/models/test_minimaxmodel.py
+++ b/test/models/test_minimaxmodel.py
@@ -1,0 +1,196 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from easyjailbreak.models.minimax_model import MiniMaxModel
+from easyjailbreak.models.openai_model import OpenaiModel
+
+
+class TestMiniMaxModel(unittest.TestCase):
+    """Unit tests for MiniMaxModel."""
+
+    # ------------------------------------------------------------------
+    # Initialisation
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_default_init(self, mock_openai_cls):
+        """Default construction uses MiniMax-M2.7 and the MiniMax base URL."""
+        model = MiniMaxModel(api_keys='test-key')
+        self.assertEqual(model.model_name, 'MiniMax-M2.7')
+        mock_openai_cls.assert_called_once_with(
+            api_key='test-key',
+            base_url='https://api.minimax.io/v1',
+        )
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_custom_model_name(self, mock_openai_cls):
+        """Users can choose a different MiniMax model variant."""
+        model = MiniMaxModel(api_keys='k', model_name='MiniMax-M2.7-highspeed')
+        self.assertEqual(model.model_name, 'MiniMax-M2.7-highspeed')
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_isinstance_openai_model(self, mock_openai_cls):
+        """MiniMaxModel must pass isinstance checks for OpenaiModel."""
+        model = MiniMaxModel(api_keys='k')
+        self.assertIsInstance(model, OpenaiModel)
+
+    # ------------------------------------------------------------------
+    # Temperature clamping
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_temperature_clamped_to_min(self, mock_openai_cls):
+        """Temperature=0 should be clamped to 0.01."""
+        model = MiniMaxModel(api_keys='k', generation_config={'temperature': 0})
+        self.assertAlmostEqual(model.generation_config['temperature'], 0.01)
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_temperature_clamped_to_max(self, mock_openai_cls):
+        """Temperature above 1 should be clamped to 1.0."""
+        model = MiniMaxModel(api_keys='k', generation_config={'temperature': 2.0})
+        self.assertAlmostEqual(model.generation_config['temperature'], 1.0)
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_temperature_in_range_unchanged(self, mock_openai_cls):
+        """Valid temperature should pass through unchanged."""
+        model = MiniMaxModel(api_keys='k', generation_config={'temperature': 0.7})
+        self.assertAlmostEqual(model.generation_config['temperature'], 0.7)
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_no_temperature_key(self, mock_openai_cls):
+        """Config without temperature should be left as-is."""
+        model = MiniMaxModel(api_keys='k', generation_config={'max_tokens': 512})
+        self.assertNotIn('temperature', model.generation_config)
+        self.assertEqual(model.generation_config['max_tokens'], 512)
+
+    # ------------------------------------------------------------------
+    # Think-tag stripping
+    # ------------------------------------------------------------------
+
+    def test_strip_think_tags_simple(self):
+        """Single <think> block is removed."""
+        text = '<think>internal reasoning</think>Hello world'
+        self.assertEqual(MiniMaxModel._strip_think_tags(text), 'Hello world')
+
+    def test_strip_think_tags_multiline(self):
+        """Multiline <think> blocks are removed."""
+        text = '<think>\nstep 1\nstep 2\n</think>\nAnswer: 42'
+        self.assertEqual(MiniMaxModel._strip_think_tags(text), 'Answer: 42')
+
+    def test_strip_think_tags_multiple(self):
+        """Multiple <think> blocks are all removed."""
+        text = '<think>a</think>Hello <think>b</think>world'
+        self.assertEqual(MiniMaxModel._strip_think_tags(text), 'Hello world')
+
+    def test_strip_think_tags_no_tags(self):
+        """Text without <think> tags is returned unchanged."""
+        text = 'Just normal text'
+        self.assertEqual(MiniMaxModel._strip_think_tags(text), 'Just normal text')
+
+    def test_strip_think_tags_none(self):
+        """None input returns None."""
+        self.assertIsNone(MiniMaxModel._strip_think_tags(None))
+
+    # ------------------------------------------------------------------
+    # Generate (with think-tag stripping + temp clamping)
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_generate_strips_think_tags(self, mock_openai_cls):
+        """generate() should strip <think> tags from the response."""
+        model = MiniMaxModel(api_keys='k')
+
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content='<think>reasoning</think>The answer is 42'))
+        ]
+        model.client.chat.completions.create.return_value = mock_response
+
+        result = model.generate('What is the answer?')
+        self.assertEqual(result, 'The answer is 42')
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_generate_clamps_kwarg_temperature(self, mock_openai_cls):
+        """generate() should clamp temperature passed as a keyword arg."""
+        model = MiniMaxModel(api_keys='k')
+
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content='Hello'))
+        ]
+        model.client.chat.completions.create.return_value = mock_response
+
+        model.generate('Hi', temperature=0)
+
+        call_kwargs = model.client.chat.completions.create.call_args
+        self.assertGreaterEqual(call_kwargs.kwargs.get('temperature', call_kwargs[1].get('temperature', 0.01)), 0.01)
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_generate_plain_text(self, mock_openai_cls):
+        """generate() returns plain text when no think tags are present."""
+        model = MiniMaxModel(api_keys='k')
+
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content='Plain response'))
+        ]
+        model.client.chat.completions.create.return_value = mock_response
+
+        result = model.generate('Hello')
+        self.assertEqual(result, 'Plain response')
+
+    # ------------------------------------------------------------------
+    # Batch generate
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_batch_generate(self, mock_openai_cls):
+        """batch_generate() should return stripped results for each conversation."""
+        model = MiniMaxModel(api_keys='k')
+
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content='<think>x</think>Answer'))
+        ]
+        model.client.chat.completions.create.return_value = mock_response
+
+        results = model.batch_generate([['q1'], ['q2']])
+        self.assertEqual(len(results), 2)
+        self.assertTrue(all(r == 'Answer' for r in results))
+
+    # ------------------------------------------------------------------
+    # System message
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_set_system_message(self, mock_openai_cls):
+        """set_system_message() should work (inherited from OpenaiModel)."""
+        model = MiniMaxModel(api_keys='k')
+        model.set_system_message('You are a helpful assistant.')
+        self.assertEqual(model.conversation.system_message, 'You are a helpful assistant.')
+
+    # ------------------------------------------------------------------
+    # Conversation attribute
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_has_conversation_attribute(self, mock_openai_cls):
+        """MiniMaxModel must have 'conversation' attribute for attacker compat."""
+        model = MiniMaxModel(api_keys='k')
+        self.assertTrue(hasattr(model, 'conversation'))
+
+    # ------------------------------------------------------------------
+    # Generation config not mutated
+    # ------------------------------------------------------------------
+
+    @patch('easyjailbreak.models.openai_model.OpenAI')
+    def test_original_config_not_mutated(self, mock_openai_cls):
+        """The original dict passed as generation_config should not be mutated."""
+        original = {'temperature': 0, 'max_tokens': 100}
+        original_copy = dict(original)
+        MiniMaxModel(api_keys='k', generation_config=original)
+        self.assertEqual(original, original_copy)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/models/test_minimaxmodel_integration.py
+++ b/test/models/test_minimaxmodel_integration.py
@@ -1,0 +1,71 @@
+"""
+Integration tests for MiniMaxModel.
+
+These tests verify end-to-end behaviour against the live MiniMax API.
+They are skipped when the ``MINIMAX_API_KEY`` environment variable is not set.
+
+Run with:
+    MINIMAX_API_KEY=your_key python -m pytest test/models/test_minimaxmodel_integration.py -v
+"""
+
+import os
+import unittest
+
+from easyjailbreak.models.minimax_model import MiniMaxModel
+from easyjailbreak.models.openai_model import OpenaiModel
+
+_API_KEY = os.environ.get('MINIMAX_API_KEY', '')
+_SKIP_REASON = 'MINIMAX_API_KEY not set'
+
+
+@unittest.skipUnless(_API_KEY, _SKIP_REASON)
+class TestMiniMaxModelIntegration(unittest.TestCase):
+    """Integration tests that call the real MiniMax API."""
+
+    def test_generate_simple_prompt(self):
+        """Model should return a non-empty response to a simple prompt."""
+        model = MiniMaxModel(api_keys=_API_KEY)
+        response = model.generate('What is 2 + 2? Reply with just the number.')
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response) > 0)
+        self.assertIn('4', response)
+
+    def test_generate_with_generation_config(self):
+        """generation_config parameters are forwarded to the API."""
+        model = MiniMaxModel(
+            api_keys=_API_KEY,
+            generation_config={'temperature': 0.5, 'max_tokens': 256},
+        )
+        response = model.generate('Say hello in one word.')
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response) > 0)
+
+    def test_batch_generate(self):
+        """batch_generate returns one response per conversation."""
+        model = MiniMaxModel(api_keys=_API_KEY, generation_config={'max_tokens': 256})
+        responses = model.batch_generate([
+            ['Say yes.'],
+            ['Say no.'],
+        ])
+        self.assertEqual(len(responses), 2)
+        self.assertTrue(all(isinstance(r, str) and len(r) > 0 for r in responses))
+
+    def test_isinstance_openai_model(self):
+        """Live model instance passes OpenaiModel isinstance check."""
+        model = MiniMaxModel(api_keys=_API_KEY)
+        self.assertIsInstance(model, OpenaiModel)
+
+    def test_highspeed_model(self):
+        """MiniMax-M2.7-highspeed variant should work."""
+        model = MiniMaxModel(
+            api_keys=_API_KEY,
+            model_name='MiniMax-M2.7-highspeed',
+            generation_config={'max_tokens': 256},
+        )
+        response = model.generate('Say OK.')
+        self.assertIsInstance(response, str)
+        self.assertTrue(len(response) > 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimaxi.com) as a first-class LLM provider for jailbreak attack, evaluation, and target model roles.

- **New `MiniMaxModel` class** (`easyjailbreak/models/minimax_model.py`) inherits from `OpenaiModel`, so all existing `isinstance(model, OpenaiModel)` checks in PAIR, TAP, IntrospectGeneration, etc. work out of the box
- Uses the OpenAI-compatible endpoint at `https://api.minimax.io/v1`
- Models: MiniMax-M2.7 (default), MiniMax-M2.7-highspeed, MiniMax-M2.5, MiniMax-M2.5-highspeed (all 204K context)
- Temperature clamping to MiniMax-supported range (0, 1]
- Automatic think tag stripping from M2.7 reasoning output
- README updated with MiniMax usage example

## Files changed (5 files, 373 additions)

| File | Change |
|---|---|
| `easyjailbreak/models/minimax_model.py` | New MiniMaxModel class |
| `easyjailbreak/models/__init__.py` | Export MiniMaxModel |
| `README.md` | MiniMax usage example |
| `test/models/test_minimaxmodel.py` | 19 unit tests |
| `test/models/test_minimaxmodel_integration.py` | 5 integration tests |

## Usage

```python
from easyjailbreak.models.minimax_model import MiniMaxModel

target_model = MiniMaxModel(api_keys='YOUR_MINIMAX_API_KEY')
response = target_model.generate('Hello, how are you?')
```

## Test plan

- [x] 19 unit tests pass
- [x] 5 integration tests pass against live MiniMax API
- [x] isinstance(model, OpenaiModel) returns True
- [ ] Verify no regressions in existing test suite